### PR TITLE
Correct handling of empty onDone handler in eval

### DIFF
--- a/sdk-remote/src/libuco/uobject-common.cc
+++ b/sdk-remote/src/libuco/uobject-common.cc
@@ -163,7 +163,7 @@ namespace urbi
         taskLock);
        GD_FINFO_TRACE("Queued async op: with lock %s: %s", taskLock.get(),
                       h->getState());
-      if (h->getState() == libport::ThreadPool::TaskHandle::DROPPED)
+      if (h->getState() == libport::ThreadPool::TaskHandle::DROPPED && onDone)
       {
         UValue res;
         onDone(res, 0);


### PR DESCRIPTION
The code that lead to this issue was following

```
UBindVar(UTest, someInputPort);
UNotifyThreadedChange(
    someInputPort,
    &UTest::onChange,
    urbi::LOCK_FUNCTION_DROP
);
```

It worked fine when no dropping occured or when only LOCK_FUNCTION (no
dropping) was used.

I don't know what the 'onDone' handler is for but obviously the case
when it's empty wasn't handled (got Boost exception
'boost::bad_function_call').
